### PR TITLE
[기능] 형식에 맞게 비디오 정보를 반환하는 기능

### DIFF
--- a/src/main/java/team7/inplace/video/DTO/PlaceForVideo.java
+++ b/src/main/java/team7/inplace/video/DTO/PlaceForVideo.java
@@ -1,0 +1,4 @@
+package team7.inplace.video.DTO;
+
+public record PlaceForVideo(Long placeId, String placeName) {
+}

--- a/src/main/java/team7/inplace/video/DTO/VideoData.java
+++ b/src/main/java/team7/inplace/video/DTO/VideoData.java
@@ -1,0 +1,4 @@
+package team7.inplace.video.DTO;
+
+public record VideoData(Long videoId, String videoAlias, String videoUrl, PlaceForVideo place) {
+}

--- a/src/main/java/team7/inplace/video/DTO/VideoResponse.java
+++ b/src/main/java/team7/inplace/video/DTO/VideoResponse.java
@@ -1,0 +1,7 @@
+package team7.inplace.video.DTO;
+
+public record VideoResponse(Long videoId, String videoAlias, String videoUrl, PlaceForVideo place) {
+    public VideoResponse(VideoData videoData) {
+        this(videoData.videoId(), videoData.videoAlias(), videoData.videoUrl(), videoData.place());
+    }
+}

--- a/src/main/java/team7/inplace/video/controller/VideoController.java
+++ b/src/main/java/team7/inplace/video/controller/VideoController.java
@@ -1,0 +1,32 @@
+package team7.inplace.video.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team7.inplace.video.DTO.VideoData;
+import team7.inplace.video.DTO.VideoResponse;
+import team7.inplace.video.service.VideoService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class VideoController {
+    private final VideoService videoService;
+
+    public VideoController(VideoService videoService) {
+        this.videoService = videoService;
+    }
+
+    // 내 인플루언서가 방문한 그 곳
+    @GetMapping("video")
+    public ResponseEntity<List<VideoResponse>> readByInfluencer(
+            @RequestParam(name="influencer", required = false) List<String> influencers
+    ){
+        List<VideoData> videoDatas = videoService.findByInfluencer(influencers);
+        List<VideoResponse> videoInfo = videoDatas.stream().map(VideoResponse::new).toList();
+        return new ResponseEntity<>(videoInfo, HttpStatus.OK);
+    }
+}

--- a/src/main/java/team7/inplace/video/entity/Influencer.java
+++ b/src/main/java/team7/inplace/video/entity/Influencer.java
@@ -1,0 +1,17 @@
+package team7.inplace.video.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Influencer {
+    /*
+     * 더미 데이터 입니다 !!!
+     */
+    @Id
+    private Long id;
+
+    protected Influencer() {
+
+    }
+}

--- a/src/main/java/team7/inplace/video/entity/Influencer.java
+++ b/src/main/java/team7/inplace/video/entity/Influencer.java
@@ -1,15 +1,24 @@
 package team7.inplace.video.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Influencer {
     /*
      * 더미 데이터 입니다 !!!
      */
     @Id
     private Long id;
+    @Column
+    private String name;
+    @Column
+    private String job;
+    @Column
+    private String imgUrl;
 
     protected Influencer() {
 

--- a/src/main/java/team7/inplace/video/entity/Place.java
+++ b/src/main/java/team7/inplace/video/entity/Place.java
@@ -1,15 +1,20 @@
 package team7.inplace.video.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Place {
     /*
      * 더미 데이터 입니다 !!!
      */
     @Id
     private Long id;
+    @Column
+    private String name;
 
     protected Place(){
 

--- a/src/main/java/team7/inplace/video/entity/Place.java
+++ b/src/main/java/team7/inplace/video/entity/Place.java
@@ -1,0 +1,17 @@
+package team7.inplace.video.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Place {
+    /*
+     * 더미 데이터 입니다 !!!
+     */
+    @Id
+    private Long id;
+
+    protected Place(){
+
+    }
+}

--- a/src/main/java/team7/inplace/video/entity/Video.java
+++ b/src/main/java/team7/inplace/video/entity/Video.java
@@ -1,0 +1,22 @@
+package team7.inplace.video.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Video {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name="video_url")
+    private String videoUrl;
+    @ManyToOne
+    @JoinColumn(name = "influencer_id")
+    private Influencer influencer;
+    @ManyToOne
+    @JoinColumn(name = "place_id")
+    private Place place;
+}

--- a/src/main/java/team7/inplace/video/repository/InfluencerRepository.java
+++ b/src/main/java/team7/inplace/video/repository/InfluencerRepository.java
@@ -1,0 +1,15 @@
+package team7.inplace.video.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team7.inplace.video.entity.Influencer;
+
+import java.util.List;
+
+public interface InfluencerRepository extends JpaRepository<Influencer, Long> {
+    // 더미 데이터 입니다!!
+
+    @Override
+    List<Influencer> findAllById(Iterable<Long> longs);
+
+    List<Influencer> findByNameIn(List<String> names);
+}

--- a/src/main/java/team7/inplace/video/repository/VideoRepository.java
+++ b/src/main/java/team7/inplace/video/repository/VideoRepository.java
@@ -1,0 +1,10 @@
+package team7.inplace.video.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team7.inplace.video.entity.Video;
+
+import java.util.List;
+
+public interface VideoRepository extends JpaRepository<Video, Long> {
+    List<Video> findVideosByInfluencerIdIn(List<Long> influencerIds);
+}

--- a/src/main/java/team7/inplace/video/service/VideoService.java
+++ b/src/main/java/team7/inplace/video/service/VideoService.java
@@ -1,0 +1,45 @@
+package team7.inplace.video.service;
+
+import org.springframework.stereotype.Service;
+import team7.inplace.video.DTO.PlaceForVideo;
+import team7.inplace.video.DTO.VideoData;
+import team7.inplace.video.entity.Influencer;
+import team7.inplace.video.entity.Video;
+import team7.inplace.video.repository.InfluencerRepository;
+import team7.inplace.video.repository.VideoRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class VideoService {
+    private final VideoRepository videoRepository;
+    private final InfluencerRepository influencerRepository;
+
+    public VideoService(VideoRepository videoRepository, InfluencerRepository influencerRepository) {
+        this.videoRepository = videoRepository;
+        this.influencerRepository = influencerRepository;
+    }
+
+    public List<VideoData> findByInfluencer(List<String> influencers){
+        // 변수명 변경 가능
+        List<VideoData> returnValue = new ArrayList<>();
+
+        // 인플루언서 정보 처리
+        List<Influencer> savedInfluencers = influencerRepository.findByNameIn(influencers);
+        List<Long> influencerIds = savedInfluencers.stream()
+                .map(Influencer::getId)
+                .toList();
+
+        // 인플루언서 정보로 필터링한 비디오 정보 불러오기
+        List<Video> savedVideos = videoRepository.findVideosByInfluencerIdIn(influencerIds);
+
+        // DTO 형식에 맞게 대입
+        for (Video savedVideo : savedVideos) {
+            PlaceForVideo placeForVideo = new PlaceForVideo(savedVideo.getPlace().getId(), savedVideo.getPlace().getName());
+            returnValue.add(new VideoData(savedVideo.getId(), " ", savedVideo.getVideoUrl(), placeForVideo));
+        }
+
+        return returnValue;
+    }
+}


### PR DESCRIPTION
### ✨ 작업 내용

- 비디오 도메인의 기본 동작을 수행하는 기능 구현
- 인플루언서 정보를 받아 해당 인플루언서들의 영상을 반환하는 API 구현

### ✨ 참고 사항

- 연관관계가 있지만 현재 협업 진행 중인 도메인에 대해서는 stub 느낌으로 더미 데이터를 만들어 넣었습니다 ( Influencer, Place )
- 비디오와 인플루언서, 장소는 각각 다대일 연관관계를 적용하였습니다.
- DTO 클래스는 Record 클래스로 작성했습니다.
- VideoService에서 구현한 비즈니스 로직이 현재 조금 비효율적인 것 같습니다, 해당 부분에 대해 의견 있으시면 말씀해주세요!

### ⏰ 현재 버그

- 발견되지 않음

### ✏ Git Close
