### PR TITLE
[fix] PlaceDetailInfo.MenuInfos timeExp 직렬화 적용

### DIFF
--- a/src/main/java/team7/inplace/place/application/dto/PlaceDetailInfo.java
+++ b/src/main/java/team7/inplace/place/application/dto/PlaceDetailInfo.java
@@ -1,5 +1,6 @@
 package team7.inplace.place.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
@@ -45,6 +46,7 @@ public record PlaceDetailInfo(
 
     public record MenuInfos(
         List<MenuInfo> menuList,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime timeExp
     ) {
 

--- a/src/main/java/team7/inplace/security/config/SecurityUtilConfig.java
+++ b/src/main/java/team7/inplace/security/config/SecurityUtilConfig.java
@@ -1,6 +1,7 @@
 package team7.inplace.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import team7.inplace.security.util.CookieUtil;
@@ -11,7 +12,9 @@ public class SecurityUtilConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
     }
 
     @Bean


### PR DESCRIPTION
관련 이슈: #7

### ✨ 작업 내용
- 기존에 직렬화 되지 않았던 LocalDateTime timeExp에 직렬화를 적용했습니다.
- security.config.SecurityUtilConfig의 ObjectMapper 빈에 JavaTimeModule을 추가했습니다.
---

### ✨ 참고 사항
- 상기했듯이 Security 패키지의 ObjectMapper 빈을 수정했습니다. Approve전에 검토 부탁드립니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close
