### PR TITLE
[Feat, Test, Refactor] 조회수 기반 동영상 정렬 및 조회 기능을 만들었어요

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,15 +53,11 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
+    // Thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }

--- a/src/main/java/team7/inplace/video/application/VideoService.java
+++ b/src/main/java/team7/inplace/video/application/VideoService.java
@@ -31,8 +31,7 @@ public class VideoService {
     private final PlaceRepository placeRepository;
     private final InfluencerRepository influencerRepository;
 
-    public Page<VideoInfo> getVideosBySurround(VideoSearchParams videoSearchParams,
-                                               Pageable pageable) {
+    public Page<VideoInfo> getVideosBySurround(VideoSearchParams videoSearchParams, Pageable pageable) {
         // Place 엔티티 조회
         Page<Place> places = placeRepository.findPlacesByDistanceAndFilters(
                 videoSearchParams.topLeftLongitude(),
@@ -41,8 +40,8 @@ public class VideoService {
                 videoSearchParams.bottomRightLatitude(),
                 videoSearchParams.longitude(),
                 videoSearchParams.latitude(),
-                new ArrayList<>(),
-                new ArrayList<>(),
+                null,
+                null,
                 pageable
         );
         // 조회된 엔티티가 비어있는지 아닌지 확인
@@ -55,7 +54,7 @@ public class VideoService {
             videos.add(videoRepository.findTopByPlaceOrderByIdDesc(place)
                     .orElseThrow(() -> InplaceException.of(VideoErrorCode.NOT_FOUND)));
         }
-        return new PageImpl<>(videos).map(this::videoToInfo);
+        return new PageImpl<>(videos, pageable, videos.size()).map(this::videoToInfo);
     }
 
     public Page<VideoInfo> getAllVideosDesc(Pageable pageable) {

--- a/src/main/java/team7/inplace/video/application/VideoService.java
+++ b/src/main/java/team7/inplace/video/application/VideoService.java
@@ -1,8 +1,5 @@
 package team7.inplace.video.application;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -21,6 +18,10 @@ import team7.inplace.video.application.dto.VideoInfo;
 import team7.inplace.video.domain.Video;
 import team7.inplace.video.persistence.VideoRepository;
 import team7.inplace.video.presentation.dto.VideoSearchParams;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -60,6 +61,14 @@ public class VideoService {
     public Page<VideoInfo> getAllVideosDesc(Pageable pageable) {
         // id를 기준으로 내림차순 정렬하여 비디오 정보 불러오기
         Page<Video> videos = videoRepository.findAllByOrderByIdDesc(pageable);
+
+        // DTO 형식에 맞게 대입
+        return videos.map(this::videoToInfo);
+    }
+
+    public Page<VideoInfo> getCoolVideo(Pageable pageable) {
+        // 조회수 증가량을 기준으로 오름차순 정렬하여 비디오 정보 불러오기
+        Page<Video> videos = videoRepository.findVideosByOrderByViewCountIncreaseDesc(pageable);
 
         // DTO 형식에 맞게 대입
         return videos.map(this::videoToInfo);

--- a/src/main/java/team7/inplace/video/domain/Video.java
+++ b/src/main/java/team7/inplace/video/domain/Video.java
@@ -59,7 +59,7 @@ public class Video {
     public void updateViewCount(Long viewCount) {
         if (this.viewCount == -1L) {
             this.viewCount = viewCount;
-            this.viewCountIncrease = 0L;
+            this.viewCountIncrease = viewCount;
             return;
         }
 

--- a/src/main/java/team7/inplace/video/persistence/VideoRepository.java
+++ b/src/main/java/team7/inplace/video/persistence/VideoRepository.java
@@ -1,12 +1,13 @@
 package team7.inplace.video.persistence;
 
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team7.inplace.place.domain.Place;
 import team7.inplace.video.domain.Video;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface VideoRepository extends JpaRepository<Video, Long> {
 
@@ -22,5 +23,5 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 
     List<Video> findByPlaceId(Long placeId);
 
-    boolean existsByPlaceId(Long placeId);
+    Page<Video> findVideosByOrderByViewCountIncreaseDesc(Pageable pageable);
 }

--- a/src/main/java/team7/inplace/video/presentation/VideoController.java
+++ b/src/main/java/team7/inplace/video/presentation/VideoController.java
@@ -2,19 +2,18 @@ package team7.inplace.video.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import team7.inplace.video.application.VideoFacade;
 import team7.inplace.video.application.VideoService;
 import team7.inplace.video.presentation.dto.VideoResponse;
 import team7.inplace.video.presentation.dto.VideoSearchParams;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,8 +46,9 @@ public class VideoController implements VideoControllerApiSpec {
     public ResponseEntity<Page<VideoResponse>> readByCool(
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
-        List<VideoResponse> videoResponses = new ArrayList<>();
-        return new ResponseEntity<>(new PageImpl<>(videoResponses, pageable, 0), HttpStatus.OK);
+        Page<VideoResponse> videoResponses = videoService.getCoolVideo(pageable)
+                .map(VideoResponse::from);
+        return new ResponseEntity<>(videoResponses, HttpStatus.OK);
     }
 
     // 토큰 필요 메서드

--- a/src/main/java/team7/inplace/video/presentation/VideoController.java
+++ b/src/main/java/team7/inplace/video/presentation/VideoController.java
@@ -21,8 +21,8 @@ public class VideoController implements VideoControllerApiSpec {
 
     @GetMapping()
     public ResponseEntity<Page<VideoResponse>> readVideos(
-            @RequestParam String longitude,
-            @RequestParam String latitude,
+            @RequestParam(value = "longitude", defaultValue = "10.0") String longitude,
+            @RequestParam(value = "latitude", defaultValue = "10.0") String latitude,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
         VideoSearchParams searchParams = VideoSearchParams.from(longitude, latitude);

--- a/src/main/java/team7/inplace/video/presentation/VideoController.java
+++ b/src/main/java/team7/inplace/video/presentation/VideoController.java
@@ -6,10 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team7.inplace.video.application.VideoFacade;
 import team7.inplace.video.application.VideoService;
 import team7.inplace.video.presentation.dto.VideoResponse;
@@ -24,9 +21,11 @@ public class VideoController implements VideoControllerApiSpec {
 
     @GetMapping()
     public ResponseEntity<Page<VideoResponse>> readVideos(
-            @ModelAttribute VideoSearchParams searchParams,
+            @RequestParam String longitude,
+            @RequestParam String latitude,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
+        VideoSearchParams searchParams = VideoSearchParams.from(longitude, latitude);
         Page<VideoResponse> videoResponses = videoService.getVideosBySurround(searchParams, pageable)
                 .map(VideoResponse::from);
         return new ResponseEntity<>(videoResponses, HttpStatus.OK);

--- a/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
+++ b/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
@@ -12,7 +12,7 @@ import team7.inplace.video.presentation.dto.VideoSearchParams;
 public interface VideoControllerApiSpec {
     @Operation(
             summary = "내 주변 그곳 ",
-            description = "Parameter로 입력받은 위치의 주변 장소들을 조회합니다."
+            description = "Parameter로 입력받은 위치의 주변 장소 Video를 조회합니다."
     )
     ResponseEntity<Page<VideoResponse>> readVideos(
             @ModelAttribute VideoSearchParams searchParams,

--- a/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
+++ b/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestParam;
 import team7.inplace.video.presentation.dto.VideoResponse;
 import team7.inplace.video.presentation.dto.VideoSearchParams;
 
@@ -30,7 +29,7 @@ public interface VideoControllerApiSpec {
 
     @Operation(
             summary = "쿨한 그 곳",
-            description = "조회수를 기준으로 내림차순 정렬한 Video 정보를 조회합니다."
+            description = "조회수 증가량을 기준으로 내림차순 정렬한 Video 정보를 조회합니다."
     )
     ResponseEntity<Page<VideoResponse>> readByCool(
             @PageableDefault(page = 0, size = 10) Pageable pageable

--- a/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
+++ b/src/main/java/team7/inplace/video/presentation/VideoControllerApiSpec.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
 import team7.inplace.video.presentation.dto.VideoResponse;
 import team7.inplace.video.presentation.dto.VideoSearchParams;
 
@@ -15,7 +16,8 @@ public interface VideoControllerApiSpec {
             description = "Parameter로 입력받은 위치의 주변 장소 Video를 조회합니다."
     )
     ResponseEntity<Page<VideoResponse>> readVideos(
-            @ModelAttribute VideoSearchParams searchParams,
+            @RequestParam String longitude,
+            @RequestParam String latitude,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     );
 

--- a/src/main/java/team7/inplace/video/presentation/dto/VideoSearchParams.java
+++ b/src/main/java/team7/inplace/video/presentation/dto/VideoSearchParams.java
@@ -24,18 +24,18 @@ public record VideoSearchParams(
     }
 
     private static String calculateTopLeftLongitude(String longitude) {
-        return String.valueOf(Double.parseDouble(longitude) - 2.5); // example shift
+        return String.valueOf(Double.parseDouble(longitude) - 5.0);
     }
 
     private static String calculateTopLeftLatitude(String latitude) {
-        return String.valueOf(Double.parseDouble(latitude) + 2.5); // example shift
+        return String.valueOf(Double.parseDouble(latitude) + 5.0);
     }
 
     private static String calculateBottomRightLongitude(String longitude) {
-        return String.valueOf(Double.parseDouble(longitude) + 2.5); // example shift
+        return String.valueOf(Double.parseDouble(longitude) + 5.0);
     }
 
     private static String calculateBottomRightLatitude(String latitude) {
-        return String.valueOf(Double.parseDouble(latitude) - 2.5); // example shift
+        return String.valueOf(Double.parseDouble(latitude) - 5.0);
     }
 }

--- a/src/main/java/team7/inplace/video/presentation/dto/VideoSearchParams.java
+++ b/src/main/java/team7/inplace/video/presentation/dto/VideoSearchParams.java
@@ -8,4 +8,34 @@ public record VideoSearchParams(
         String longitude,
         String latitude
 ) {
+    private VideoSearchParams(String longitude, String latitude) {
+        this(
+                calculateTopLeftLongitude(longitude),   // topLeftLongitude
+                calculateTopLeftLatitude(latitude),     // topLeftLatitude
+                calculateBottomRightLongitude(longitude), // bottomRightLongitude
+                calculateBottomRightLatitude(latitude),   // bottomRightLatitude
+                longitude,
+                latitude
+        );
+    }
+
+    public static VideoSearchParams from(String longitude, String latitude){
+        return new VideoSearchParams(longitude, latitude);
+    }
+
+    private static String calculateTopLeftLongitude(String longitude) {
+        return String.valueOf(Double.parseDouble(longitude) - 2.5); // example shift
+    }
+
+    private static String calculateTopLeftLatitude(String latitude) {
+        return String.valueOf(Double.parseDouble(latitude) + 2.5); // example shift
+    }
+
+    private static String calculateBottomRightLongitude(String longitude) {
+        return String.valueOf(Double.parseDouble(longitude) + 2.5); // example shift
+    }
+
+    private static String calculateBottomRightLatitude(String latitude) {
+        return String.valueOf(Double.parseDouble(latitude) - 2.5); // example shift
+    }
 }

--- a/src/test/java/team7/inplace/util/TestUtil.java
+++ b/src/test/java/team7/inplace/util/TestUtil.java
@@ -1,0 +1,15 @@
+package team7.inplace.util;
+
+import java.lang.reflect.Field;
+
+public final class TestUtil {
+    public static void setId(Object entity, Long id) {
+        try {
+            Field idField = entity.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(entity, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/team7/inplace/video/application/VideoServiceTest.java
+++ b/src/test/java/team7/inplace/video/application/VideoServiceTest.java
@@ -2,9 +2,12 @@ package team7.inplace.video.application;
 
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,75 +15,249 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import team7.inplace.influencer.domain.Influencer;
 import team7.inplace.influencer.persistence.InfluencerRepository;
+import team7.inplace.place.application.dto.PlaceForVideo;
 import team7.inplace.place.domain.*;
-import team7.inplace.video.application.VideoService;
+import team7.inplace.place.persistence.PlaceRepository;
+import team7.inplace.util.TestUtil;
 import team7.inplace.video.application.dto.VideoInfo;
 import team7.inplace.video.domain.Video;
 import team7.inplace.video.persistence.VideoRepository;
+import team7.inplace.video.presentation.dto.VideoSearchParams;
 
 @ExtendWith(MockitoExtension.class)
 public class VideoServiceTest {
     @Mock
     private VideoRepository videoRepository;
     @Mock
+    private PlaceRepository placeRepository;
+    @Mock
     private InfluencerRepository influencerRepository;
     @InjectMocks
     private VideoService videoService;
 
     @Test
-    @DisplayName("findByInfluencer Test")
-    void test1() {
-//        // given
-//        ArgumentCaptor<List<String>> captor_s = ArgumentCaptor.forClass((Class) List.class);
-//        ArgumentCaptor<List<Long>> captor_i = ArgumentCaptor.forClass((Class) List.class);
-//
-//        Place place = Place.builder()
-//                .name("Test Place")
-//                .pet(false)
-//                .wifi(true)
-//                .parking(false)
-//                .fordisabled(true)
-//                .nursery(false)
-//                .smokingroom(false)
-//                .address(new Address("Address 1", "Address 2", "Address 3"))
-//                .menuImgUrl("menu.jpg")
-//                .category(Category.CAFE)
-//                .coordinate(new Coordinate("127.0", "37.0"))
-//                .timeList(Arrays.asList(
-//                        new OpenPeriod("Opening Hours", "9:00 AM", "Monday"),
-//                        new OpenPeriod("Closing Hours", "10:00 PM", "Monday")
-//                ))
-//                .menuList(Arrays.asList(
-//                        new Menu(5000L, true, "Coffee"),
-//                        new Menu(7000L, false, "Cake")
-//                ))
-//                .build();
-//        Influencer influencer = new Influencer("성시경", "가수", "imgUrl");
-//        Video video = new Video("url", influencer, place);
-//
-//        // 함수 매개변수
-//        List<String> names = new ArrayList<>();
-//        names.add("성시경");
-//
-//        // influencerRepository.findByNameIn의 결과
-//        List<Influencer> influencers = new ArrayList<>();
-//        influencers.add(influencer);
-//        given(influencerRepository.findByNameIn(captor_s.capture())).willAnswer(invocation -> influencers);
-//
-//        // videoRepository.findVideosByInfluencerIdIn의 결과
-//        List<Video> savedVideos = new ArrayList<>();
-//        savedVideos.add(video);
-//        given(videoRepository.findVideosByInfluencerIdIn(captor_i.capture())).willAnswer(invocation -> savedVideos);
-//
-//        // when
-//        List<VideoInfo> savedVideoData = videoService.findByInfluencer(names);
-//        // then
-//        Assertions.assertThat(savedVideoData.get(0).place().placeName()).isEqualTo(place.getName());
-//        Assertions.assertThat(savedVideoData.get(0).videoUrl()).isEqualTo("url");
-//        // 여러 번 실행 시 Alias 부분이 바뀌는지 검사 ( 확인 완료 )
-//        System.out.println("videoAlias(" + ") = " + savedVideoData.get(0).videoAlias());
+    @DisplayName("getVideosBySurround Test")
+    void test1(){
+        // given
+        // 매개변수
+        VideoSearchParams videoSearchParams = new VideoSearchParams(
+                "10.0",
+                "60.0",
+                "50.0",
+                "10.0",
+                "10.0",
+                "51.0"
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // Place 객체
+        Place place1 = new Place("Place 1",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "카페",
+                "Address 1|Address 2|Address 3",
+                "10.0", "10.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+        Place place2 = new Place("Place 2",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "일식",
+                "Address 1|Address 2|Address 3",
+                "10.0", "50.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+        // method 1 실행 결과 값 설정
+        List<Place> placeList = List.of(place1, place2);
+        Page<Place> places = new PageImpl<>(placeList, pageable, 2);
+        // method 1 mock 설정
+        given(placeRepository.findPlacesByDistanceAndFilters(
+                videoSearchParams.topLeftLongitude(),
+                videoSearchParams.topLeftLatitude(),
+                videoSearchParams.bottomRightLongitude(),
+                videoSearchParams.bottomRightLatitude(),
+                videoSearchParams.longitude(),
+                videoSearchParams.latitude(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                pageable)
+        ).willAnswer(invocation -> places);
+
+        // method 2 실행 결과 값 설정
+        Video video1 = Video.from(new Influencer("성시경", "url1", "가수"), place1, "url_1");
+        Video video2 = Video.from(new Influencer("성시경", "url2", "가수"), place2, "url_2");
+        // method 2 mock 설정
+        ArgumentCaptor<Place> captor_pla = ArgumentCaptor.forClass(Place.class);
+        given(videoRepository.findTopByPlaceOrderByIdDesc(captor_pla.capture())).willAnswer(
+                invocation -> {
+                    if(captor_pla.getValue() == place1)
+                        return Optional.of(video1);
+                    return Optional.of(video2);
+                }
+        );
+        // when
+        Page<VideoInfo> videoInfos = videoService.getVideosBySurround(videoSearchParams, pageable);
+        // then
+        Assertions.assertThat(videoInfos.getContent().get(0).place().placeName()).isEqualTo("Place 1");
+        Assertions.assertThat(videoInfos.getContent().get(1).place().placeName()).isEqualTo("Place 2");
+    }
+
+    @Test
+    @DisplayName("getAllVideosDesc Test")
+    void test2(){
+        // Place 객체
+        Place place1 = new Place("Place 1",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "카페",
+                "Address 1|Address 2|Address 3",
+                "10.0", "10.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+
+        // Video 객체
+        Video video1 = Video.from(new Influencer("성시경", "url", "가수"), place1, "url1");
+        TestUtil.setId(video1, 1L);
+
+        Video video2 = Video.from(new Influencer("성시경", "url", "가수"), place1, "url2");
+        TestUtil.setId(video2, 2L);
+
+        // method 1 실행 결과 값 설정
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Video> videoList = Arrays.asList(video2, video1);
+        Page<Video> videos = new PageImpl<>(videoList, pageable, 2);
+
+        given(videoRepository.findAllByOrderByIdDesc(pageable)).willAnswer(
+                invocation -> videos
+        );
+        // when
+        Page<VideoInfo> videoInfos = videoService.getAllVideosDesc(pageable);
+        // then
+        Assertions.assertThat(videoInfos.getContent().get(0).videoId()).isEqualTo(2L);
+        Assertions.assertThat(videoInfos.getContent().get(1).videoId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getVideosByMyInfluencer Test")
+    void test3() {
+        // given
+        // Place 객체
+        Place place1 = new Place("Place 1",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "카페",
+                "Address 1|Address 2|Address 3",
+                "10.0", "10.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+
+        // method 1 실행 결과 값 설정
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Long> ids = Arrays.asList(1L, 2L);
+        List<Influencer> influencers = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            Influencer influencer = new Influencer(i + "번", "url" + i, "가수");
+            influencers.add(influencer);
+            TestUtil.setId(influencer, (long) i);
+        }
+
+        Video video1 = Video.from(influencers.get(0), place1, "url_1");
+        Video video2 = Video.from(influencers.get(1), place1, "url_2");
+        Video video3 = Video.from(influencers.get(1), place1, "url_3");
+        Video video4 = Video.from(influencers.get(2), place1, "url_4");
+        List<Video> videoList = Arrays.asList(video1, video2, video3);
+        Page<Video> videos = new PageImpl<>(videoList, pageable, 3);
+
+        // method 1 설정
+        given(videoRepository.findVideosByInfluencerIdIn(ids, pageable)).willAnswer(
+                invocation -> videos
+        );
+
+        // when
+        Page<VideoInfo> videoInfos = videoService.getVideosByMyInfluencer(ids, pageable);
+
+        // then
+        Assertions.assertThat(videoInfos.getContent().size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("getPlaceNullVideo Test")
+    void test4(){
+        // Place 객체
+        Place place1 = new Place("Place 1",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "카페",
+                "Address 1|Address 2|Address 3",
+                "10.0", "10.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+
+        // Influencer 객체
+        Influencer influencer = new Influencer("성시경", "url1", "가수");
+
+        // method 1 실행 결과 설정
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Video video1 = Video.from(influencer, place1, "url_1");
+        Video video2 = Video.from(influencer, null, "url_2");
+        Video video3 = Video.from(influencer, place1, "url_3");
+        Video video4 = Video.from(influencer, null, "url_4");
+        List<Video> videoList = Arrays.asList(video2, video4);
+        Page<Video> videos = new PageImpl<>(videoList, pageable, 3);
+
+        // method 1 설정
+        given(videoRepository.findAllByPlaceIsNull(pageable)).willAnswer(
+                invocation -> videos
+        );
+
+        // when
+        Page<VideoInfo> videoInfos = videoService.getPlaceNullVideo(pageable);
+
+        //
+        Assertions.assertThat(videoInfos.getContent().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/team7/inplace/video/persistence/VideoRepositoryTest.java
+++ b/src/test/java/team7/inplace/video/persistence/VideoRepositoryTest.java
@@ -2,21 +2,33 @@ package team7.inplace.video.persistence;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import java.util.ArrayList;
-import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.annotation.DirtiesContext;
+import team7.inplace.global.exception.InplaceException;
+import team7.inplace.global.exception.code.PlaceErrorCode;
+import team7.inplace.global.exception.code.VideoErrorCode;
+import team7.inplace.global.queryDsl.QueryDslConfig;
+import team7.inplace.influencer.domain.Influencer;
 import team7.inplace.place.domain.Place;
+import team7.inplace.place.persistence.PlaceRepository;
 import team7.inplace.video.domain.Video;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @DataJpaTest
+@Import(QueryDslConfig.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) // 각 메서드 실행마다 이전 결과 초기화
 public class VideoRepositoryTest {
 
@@ -24,52 +36,64 @@ public class VideoRepositoryTest {
     EntityManager entityManager;
     @Autowired
     private VideoRepository videoRepository;
-    private Place place;
+    @Autowired
+    private PlaceRepository placeRepository;
+    private Pageable pageable = PageRequest.of(0, 10);
 
     @BeforeEach
     void init() {
-        /*
-        place = Place.builder()
-            .name("Test Place")
-            .pet(false)
-            .wifi(true)
-            .parking(false)
-            .fordisabled(true)
-            .nursery(false)
-            .smokingroom(false)
-            .address(new Address("Address 1", "Address 2", "Address 3"))
-            .menuImgUrl("menu.jpg")
-            .category(Category.CAFE)
-            .coordinate(new Coordinate("127.0", "37.0"))
-            .timeList(Arrays.asList(
-                new PlaceOpenTime("Opening Hours", "9:00 AM", "Monday"),
-                new PlaceOpenTime("Closing Hours", "10:00 PM", "Monday")
-            ))
-            .menuList(Arrays.asList(
-                new Menu(5000L, true, "Coffee", "menuImg.url"),
-                new Menu(7000L, false, "Cake", "menuImg.url")
-            ))
-            .build();
-
-        entityManager.persist(place);
+        Place place1 = new Place("Place 1",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "카페",
+                "Address 1|Address 2|Address 3",
+                "10.0", "10.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+        Place place2 = new Place("Place 2",
+                "\"wifi\": true, \"pet\": false, \"parking\": false, \"forDisabled\": true, \"nursery\": false, \"smokingRoom\": false}",
+                "menuImg.url", "일식",
+                "Address 1|Address 2|Address 3",
+                "10.0", "50.0",
+                Arrays.asList("한글날|수|N", "크리스마스|수|Y"),
+                Arrays.asList("오픈 시간|9:00 AM|월", "닫는 시간|6:00 PM|월"),
+                Arrays.asList("삼겹살|5000|false|menu.url|description",
+                        "돼지찌개|7000|true|menu.url|description"),
+                LocalDateTime.of(2024, 3, 28, 5, 30),
+                Arrays.asList(
+                        "menuBoard1.url",
+                        "menuBoard2.url"
+                )
+        );
+        entityManager.persist(place1);
+        entityManager.persist(place2);
 
         Influencer influencer1 = new Influencer("name1", "job1", "imgUrl");
         Influencer influencer2 = new Influencer("name2", "job2", "imgUrl");
         entityManager.persist(influencer1);
         entityManager.persist(influencer2);
 
-        Video video1 = new Video("url1", influencer1, place);
-        Video video2 = new Video("url2", influencer1, place);
-        Video video3 = new Video("url3", influencer1, place);
-        Video video4 = new Video("url4", influencer2, place);
-        Video video5 = new Video("url5", influencer2, place);
+        Video video1 = Video.from(influencer1, place1, "url1");
+        Video video2 = Video.from(influencer1, place1, "url2");
+        Video video3 = Video.from(influencer1, place1, "url3");
+        Video video4 = Video.from(influencer2, place2, "url4");
+        Video video5 = Video.from(influencer2, place2, "url5");
+        Video video6 = Video.from(influencer1, null, "url6");
+        Video video7 = Video.from(influencer2, null, "url7");
         entityManager.persist(video1);
         entityManager.persist(video2);
         entityManager.persist(video3);
         entityManager.persist(video4);
         entityManager.persist(video5);
-
-         */
+        entityManager.persist(video6);
+        entityManager.persist(video7);
     }
 
     @Test
@@ -83,7 +107,8 @@ public class VideoRepositoryTest {
         influencerIds.add(1L);
 
         Page<Video> savedVideos = videoRepository.findVideosByInfluencerIdIn(
-                influencerIds, PageRequest.of(0, 5)
+                influencerIds,
+                pageable
         );
         // then
         Assertions.assertThat(savedVideos.getContent().size()).isEqualTo(3);
@@ -96,7 +121,7 @@ public class VideoRepositoryTest {
         /* Before Each */
 
         // when
-        Page<Video> videos = videoRepository.findAllByOrderByIdDesc(PageRequest.of(0, 5));
+        Page<Video> videos = videoRepository.findAllByOrderByIdDesc(pageable);
 
         // then
         Long number = 5L;
@@ -107,15 +132,70 @@ public class VideoRepositoryTest {
     }
 
     @Test
-    @DisplayName("findTopByPlaceOrderByIdDesc Test")
-    void test3() {
+    @DisplayName("findAllByPlaceIsNull Test")
+    void test3(){
         // given
 
         // when
+        Page<Video> videos = videoRepository.findAllByPlaceIsNull(pageable);
+        // then
+        Assertions.assertThat(videos.getContent().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("findTopByPlaceOrderByIdDesc Test")
+    void test4() {
+        // given
+
+        // when
+        Place place = placeRepository.findById(1L).orElseThrow(()->InplaceException.of(PlaceErrorCode.NOT_FOUND));
         Video video = videoRepository.findTopByPlaceOrderByIdDesc(place).orElseThrow(NoSuchFieldError::new);
 
         // then
         Assertions.assertThat(video).isNotNull();
-        Assertions.assertThat(video.getId()).isEqualTo(5L);
+        Assertions.assertThat(video.getId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("findByPlaceIdIn Test")
+    void test5(){
+        // given
+
+        // when
+        List<Long> ids = Arrays.asList(1L, 2L);
+        List<Video> videos = videoRepository.findByPlaceIdIn(ids);
+        // then
+        Assertions.assertThat(videos.size()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("findByPlaceId Test")
+    void test6(){
+        // given
+
+        // when
+        List<Video> videos = videoRepository.findByPlaceId(1L);
+        // then
+        Assertions.assertThat(videos.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("findVideosByOrderByViewCountIncreaseDesc Test")
+    void test7(){
+        // given
+
+        // when
+        Video video1 = videoRepository.findById(1L).orElseThrow(() -> InplaceException.of(VideoErrorCode.NOT_FOUND));
+        Video video2 = videoRepository.findById(2L).orElseThrow(() -> InplaceException.of(VideoErrorCode.NOT_FOUND));
+        video1.updateViewCount(10L);
+        video2.updateViewCount(100L);
+
+        Page<Video> videos = videoRepository.findVideosByOrderByViewCountIncreaseDesc(pageable);
+        // then
+        for (Video video : videos) {
+            System.out.println("video = " + video.getId() + " " + video.getVideoUrl() + " " + video.getViewCountIncrease());
+        }
+        Assertions.assertThat(videos.getContent().size()).isEqualTo(7);
+        Assertions.assertThat(videos.getContent().get(0)).isEqualTo(video2);
     }
 }


### PR DESCRIPTION
### ✨ 작업 내용

- 빌드 파일에서 중복되는 부분을 삭제했어요
- Cool 한 그곳 API 및 기능을 구현했어요
- 비디오의 조회수 첫 업데이트 시, 0이던 조회수 증가량을 조회수와 동일하게 변경했어요
- Repository, Service 계층에 대한 유닛 테스트를 진행했어요
- 내 주변 장소의 동영상을 조회할 때, 고정적인 범위에서 가져오도록 Parameter 설정을 변경했어요

### ✨ 참고 사항

- 비디오 조회수가 맨 처음 업데이트 시에 증가량이 0이면, 등록 이후 첫 업데이트에는 cool 한 그 곳으로 선정될 수 없는 문제가 있어서 이 로직을 변경했습니다
- 고정 범위에서 장소 기준 동영상 조회시, 조회가 안되는 문제가 발생했습니다...

### ⏰ 현재 버그

- /videos API에 요청 시, 10.0 / 10.0 으로 longitude, latitude를 설정한 장소가 중심으로 오도록 범위를 잡고 조회를 해봐도 조회가 안되는 문제가 발생했습니다
  - place repository에서 QueryDSL로 처리한 로직에서의 문제인 것 같은데, 리뷰하면서 확인 부탁드려요 ㅠㅠ
  - 동일한 조건으로 테스트하거나 해서 문제를 알게되면 꼭 알려주세요 ㅠㅠ

### ✏ Git Close
