### PR TITLE
[Fix] #50 - Token이 Expire되어도 permitAll이면 허용

### DIFF
--- a/src/main/java/team7/inplace/global/exception/code/AuthorizationErrorCode.java
+++ b/src/main/java/team7/inplace/global/exception/code/AuthorizationErrorCode.java
@@ -7,9 +7,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum AuthorizationErrorCode implements ErrorCode {
-    TOKEN_IS_EMPTY(HttpStatus.BAD_REQUEST, "A001", "Token is Empty"),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A002", "Invalid Token"),
-    TOKEN_IS_EXPIRED(HttpStatus.BAD_REQUEST, "A003", "Token is Expired");
+    NOT_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "A000", "Authentication 실패"),
+    TOKEN_IS_EMPTY(HttpStatus.BAD_REQUEST, "A001", "토큰 없음"),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "A002", "Invalid 토큰"),
+    TOKEN_IS_EXPIRED(HttpStatus.BAD_REQUEST, "A003", "토큰 만료");
 
     private final HttpStatus httpStatus;
     private final String errorCode;

--- a/src/main/java/team7/inplace/global/rest/WebClientConfig.java
+++ b/src/main/java/team7/inplace/global/rest/WebClientConfig.java
@@ -1,8 +1,11 @@
 package team7.inplace.global.rest;
 
+import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class WebClientConfig {
@@ -10,6 +13,9 @@ public class WebClientConfig {
     @Bean
     public WebClient webClient() {
         return WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(
+                HttpClient.create().responseTimeout(Duration.ofMillis(60000))
+            ))
             .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
             .build();
     }

--- a/src/main/java/team7/inplace/security/filter/AuthorizationFilter.java
+++ b/src/main/java/team7/inplace/security/filter/AuthorizationFilter.java
@@ -35,8 +35,9 @@ public class AuthorizationFilter extends OncePerRequestFilter {
             return;
         }
         String token = getTokenCookie(request).getValue();
-        jwtUtil.validateExpired(token);
-        addUserToAuthentication(token);
+        if (jwtUtil.isNotExpired(token)) {
+            addUserToAuthentication(token);
+        }
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/team7/inplace/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/team7/inplace/security/handler/CustomAccessDeniedHandler.java
@@ -1,6 +1,5 @@
 package team7.inplace.security.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -11,7 +10,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
-        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        AccessDeniedException accessDeniedException) throws IOException {
         response.sendRedirect("/");
     }
 }

--- a/src/main/java/team7/inplace/security/handler/CustomFailureHandler.java
+++ b/src/main/java/team7/inplace/security/handler/CustomFailureHandler.java
@@ -5,16 +5,20 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.util.StringUtils;
 import team7.inplace.global.exception.InplaceException;
 import team7.inplace.global.exception.code.AuthorizationErrorCode;
 
 @Slf4j
 public class CustomFailureHandler implements AuthenticationFailureHandler {
 
+    @Value("${spring.redirect.front-end-url}")
+    private String frontEndUrl;
     private final ObjectMapper objectMapper;
 
     public CustomFailureHandler(ObjectMapper objectMapper) {
@@ -27,8 +31,11 @@ public class CustomFailureHandler implements AuthenticationFailureHandler {
         HttpServletResponse response,
         AuthenticationException exception
     ) throws IOException {
-        log.info("CustomFailureHandler.onAuthenticationFailure");
-        setErrorResponse(response, InplaceException.of(AuthorizationErrorCode.TOKEN_IS_EXPIRED));
+        String accept = request.getHeader("Accept");
+        if (StringUtils.hasText(accept) && accept.contains("text/html")) {
+            response.sendRedirect(frontEndUrl);
+        }
+        setErrorResponse(response, InplaceException.of(AuthorizationErrorCode.NOT_AUTHENTICATION));
     }
 
     private void setErrorResponse(

--- a/src/main/java/team7/inplace/security/handler/CustomSuccessHandler.java
+++ b/src/main/java/team7/inplace/security/handler/CustomSuccessHandler.java
@@ -1,10 +1,11 @@
 package team7.inplace.security.handler;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import team7.inplace.security.application.dto.CustomOAuth2User;
@@ -49,13 +50,15 @@ public class CustomSuccessHandler implements AuthenticationSuccessHandler {
         HttpServletResponse response,
         String accessToken, String refreshToken
     ) {
-        Cookie accessTokenCookie = CookieUtil.createCookie(TokenType.ACCESS_TOKEN.getValue(),
+        ResponseCookie accessTokenCookie = CookieUtil.createCookie(
+            TokenType.ACCESS_TOKEN.getValue(),
             accessToken);
-        Cookie refreshTokenCookie = CookieUtil.createCookie(TokenType.REFRESH_TOKEN.getValue(),
+        ResponseCookie refreshTokenCookie = CookieUtil.createCookie(
+            TokenType.REFRESH_TOKEN.getValue(),
             refreshToken);
 
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
     }
 
     private void setRedirectUrlToResponse(

--- a/src/main/java/team7/inplace/security/util/CookieUtil.java
+++ b/src/main/java/team7/inplace/security/util/CookieUtil.java
@@ -1,14 +1,16 @@
 package team7.inplace.security.util;
 
-import jakarta.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
 
-    public static Cookie createCookie(String key, String value) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60 * 60);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        return cookie;
+    public static ResponseCookie createCookie(String key, String value) {
+        return ResponseCookie.from(key, value)
+            .sameSite("Lax")
+            .secure(true)
+            .path("/")
+            .httpOnly(true)
+            .maxAge(60 * 60)
+            .build();
     }
 }

--- a/src/main/java/team7/inplace/security/util/JwtUtil.java
+++ b/src/main/java/team7/inplace/security/util/JwtUtil.java
@@ -82,13 +82,14 @@ public class JwtUtil {
         }
     }
 
-    public void validateExpired(String token) throws InplaceException {
+    public boolean isNotExpired(String token) {
         try {
             jwtParser.parseSignedClaims(token).getPayload().getExpiration();
         } catch (ExpiredJwtException e) {
-            throw InplaceException.of(AuthorizationErrorCode.TOKEN_IS_EXPIRED);
+            return false;
         } catch (JwtException | IllegalArgumentException e) {
             throw InplaceException.of(AuthorizationErrorCode.INVALID_TOKEN);
         }
+        return true;
     }
 }

--- a/src/main/java/team7/inplace/token/presentation/RefreshTokenController.java
+++ b/src/main/java/team7/inplace/token/presentation/RefreshTokenController.java
@@ -3,13 +3,16 @@ package team7.inplace.token.presentation;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team7.inplace.global.exception.InplaceException;
 import team7.inplace.global.exception.code.AuthorizationErrorCode;
+import team7.inplace.security.filter.TokenType;
 import team7.inplace.security.util.AuthorizationUtil;
 import team7.inplace.security.util.CookieUtil;
 import team7.inplace.security.util.JwtUtil;
@@ -39,12 +42,15 @@ public class RefreshTokenController implements RefreshTokenControllerApiSpec {
     }
 
     private void addTokenToCookie(HttpServletResponse response, ReIssued reIssuedToken) {
-        Cookie accessTokenCookie = CookieUtil.createCookie("access_token",
+        ResponseCookie accessTokenCookie = CookieUtil.createCookie(
+            TokenType.ACCESS_TOKEN.getValue(),
             reIssuedToken.accessToken());
-        Cookie refreshTokenCookie = CookieUtil.createCookie("refresh_token",
+        ResponseCookie refreshTokenCookie = CookieUtil.createCookie(
+            TokenType.REFRESH_TOKEN.getValue(),
             reIssuedToken.refreshToken());
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
     }
 
     private boolean cannotRefreshToken(Cookie cookie) {

--- a/src/test/java/team7/inplace/security/util/JwtUtilTest.java
+++ b/src/test/java/team7/inplace/security/util/JwtUtilTest.java
@@ -1,7 +1,6 @@
 package team7.inplace.security.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.jsonwebtoken.Jwts;
@@ -12,7 +11,6 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import team7.inplace.global.exception.InplaceException;
 import team7.inplace.security.config.JwtProperties;
 import team7.inplace.user.domain.Role;
 
@@ -73,8 +71,6 @@ class JwtUtilTest {
             .signWith(secretKey)
             .compact();
 
-        assertThatExceptionOfType(InplaceException.class).isThrownBy(
-            () -> jwtUtil.validateExpired(expiredToken)
-        );
+        assertThat(jwtUtil.isNotExpired(expiredToken)).isFalse();
     }
 }


### PR DESCRIPTION
### ✨ 작업 내용
- 기존의 permitAll 경로도 token Expired되면 차단하는 것을 고쳤습니다.
---

### ✨ 참고 사항
- Cookie에 Secure 속성을 추가하였습니다.
---

### ⏰ 현재 버그

---

### ✏ Git Close
